### PR TITLE
feature/replace-sections-with-split-content

### DIFF
--- a/scripts/content/transform.js
+++ b/scripts/content/transform.js
@@ -34,7 +34,7 @@ function parseContentEntry(rawEntry = {}) {
 		meta,
 		fields: {
 			...restFields,
-			contentSections: [], // Placeholder for future content parsing (avoids type errors)
+			sections: [], // Placeholder for future content parsing (avoids type errors)
 		},
 	};
 }

--- a/scripts/content/transform.js
+++ b/scripts/content/transform.js
@@ -64,6 +64,7 @@ function parseContentEntry(rawEntry = {}, allSections = {}) {
 		meta,
 		fields: {
 			...restFields,
+			contentSections: [], // Placeholder for future content parsing (avoids type errors)
 			sections: resolveSections(sections, allSections),
 		},
 	};

--- a/src/lib/components/layout/Hero.svelte
+++ b/src/lib/components/layout/Hero.svelte
@@ -11,7 +11,7 @@ import Section from "./Section.svelte";
 let { title, children } = $props();
 </script>
 
-<div class="hero relative mb-20">
+<div class="hero relative mb-24">
 	<div
 		class="absolute w-full min-w-5xl top-[calc(100%-72px)] left-0 overflow-hidden pointer-events-none">
 		<svg class="w-[inherit] h-40"

--- a/src/lib/data/pages.json
+++ b/src/lib/data/pages.json
@@ -16,13 +16,7 @@
 			"header": "Get to Know Me",
 			"intro": "I’m Eleni Papamikrouli, a systemic therapist working with individuals, couples, and families. Originally from Greece, I’ve lived in the Netherlands for over 15 years, giving me a unique perspective on the experiences of internationals and expats. That said, I work with people from all walks of life, offering a safe and supportive space for anyone seeking change.",
 			"content": "## My approach \nI'm practical and collaborative. I combine curiosity with empathy to help clients explore their challenges and find ways forward. You don’t need to be perfect or have all the answers—therapy is about working together to create clarity and change.\n\n## Why Systemic Therapy?\nSystemic therapy focuses on the patterns and systems we live in, rather than labeling or diagnosing individuals. It’s not about finding fault but about exploring how dynamics work and where we can make meaningful shifts. My role is to guide you in uncovering possibilities and building solutions that fit your life.",
-			"contentSections": [],
-			"sections": [
-				{
-					"title": "About - Main content",
-					"content": "## My approach \nI'm practical and collaborative. I combine curiosity with empathy to help clients explore their challenges and find ways forward. You don’t need to be perfect or have all the answers—therapy is about working together to create clarity and change.\n\n## Why Systemic Therapy?\nSystemic therapy focuses on the patterns and systems we live in, rather than labeling or diagnosing individuals. It’s not about finding fault but about exploring how dynamics work and where we can make meaningful shifts. My role is to guide you in uncovering possibilities and building solutions that fit your life."
-				}
-			]
+			"contentSections": []
 		}
 	},
 	{
@@ -42,13 +36,7 @@
 			"header": "Contact Me to Take the First Step",
 			"intro": "Taking the first step toward therapy can feel daunting, but I’m here to make it as simple as possible. Whether you’re curious about the process or ready to begin, I’d love to hear from you.",
 			"content": "## Schedule a Session\nI work with people from all over the world and all walks of life. Let’s explore how therapy can help you create positive, lasting change.\n\n[Include a link or form for booking a session.]\n\n---\n\n## Contact Details\n- **Email:** eleni@mikrouli.nl\n- **Phone:** 00 31 6 19 44 62 63\n- **Languages:** Greek, Dutch, English\n- **Location:** Online sessions available worldwide",
-			"contentSections": [],
-			"sections": [
-				{
-					"title": "Contact - Main Content",
-					"content": "## Schedule a Session\nI work with people from all over the world and all walks of life. Let’s explore how therapy can help you create positive, lasting change.\n\n[Include a link or form for booking a session.]\n\n## Contact Details\n- **Email:** eleni@mikrouli.nl\n- **Phone:** 00 31 6 19 44 62 63\n- **Languages:** Greek, Dutch, English\n- **Location:** Online sessions available worldwide"
-				}
-			]
+			"contentSections": []
 		}
 	},
 	{
@@ -68,13 +56,7 @@
 			"header": "404 - Page not found",
 			"intro": "It seems the page you’re looking for doesn’t exist—or perhaps it’s just taking a little break.",
 			"content": "## Lost? Let's Find Our Way Together\n\nJust like in life, we sometimes encounter detours that redirect us to new paths. Let’s make this moment an opportunity to move forward.\n\nYou can:\n- [Return to the homepage](/)\n- [Learn more about me and my approach](/about)\n- [Contact me for support](/contact)\n\n> Take a deep breath, and let’s keep navigating this journey together.\n\n---\n\n### Still Stuck?\n\nIf you’re finding yourself here often, don’t hesitate to reach out. I’d love to help you find what you’re looking for—or perhaps we can use this as the first step toward something new.\n\nHere’s how to get in touch:\n\n- **Email**: [eleni@mikrouli.nl](mailto:eleni@mikrouli.nl)\n- **Phone**: 00 31 6 19 44 62 63\n- **Languages**: Greek, Dutch, English\n\nOr, [schedule a session directly](/contact). \n\n> Together, we can start creating clarity and positive change.",
-			"contentSections": [],
-			"sections": [
-				{
-					"title": "404 - Main content",
-					"content": "## Lost? Let's Find Our Way Together\n\nJust like in life, we sometimes encounter detours that redirect us to new paths. Let’s make this moment an opportunity to move forward.\n\nYou can:\n- [Return to the homepage](/)\n- [Learn more about me and my approach](/about)\n- [Contact me for support](/contact)\n\n> Take a deep breath, and let’s keep navigating this journey together.\n\n---\n\n### Still Stuck?\n\nIf you’re finding yourself here often, don’t hesitate to reach out. I’d love to help you find what you’re looking for—or perhaps we can use this as the first step toward something new.\n\nHere’s how to get in touch:\n\n- **Email**: [eleni@mikrouli.nl](mailto:eleni@mikrouli.nl)\n- **Phone**: 00 31 6 19 44 62 63\n- **Languages**: Greek, Dutch, English\n\nOr, [schedule a session directly](/contact). \n\n> Together, we can start creating clarity and positive change."
-				}
-			]
+			"contentSections": []
 		}
 	},
 	{
@@ -94,8 +76,7 @@
 			"header": "Explore Ways We Can Work Together",
 			"intro": "I provide therapy for anyone seeking to improve their relationships, navigate challenges, or better understand themselves. While I bring a unique perspective to working with internationals and expats, my services are open to all who want to create positive change.",
 			"content": "## Discover Our Approach\n\nWe believe that every individual’s journey is unique, and effective therapy should honor your personal story while offering practical tools to create positive change.\n\nOur services are designed with flexibility and empathy in mind. Whether you're looking to improve your relationships, overcome personal challenges, or simply gain clarity about your life direction, our tailored approach supports your growth every step of the way.\n",
-			"contentSections": [],
-			"sections": []
+			"contentSections": []
 		}
 	},
 	{
@@ -115,8 +96,7 @@
 			"header": "Insights to Support Your Journey",
 			"intro": "Therapy is about understanding ourselves and the systems we live in. Whether you're an international, an expat, or simply someone navigating life’s challenges, these articles offer insights and tools to support your journey.\n",
 			"content": "You'll discover concise, insightful articles that offer practical tools and fresh perspectives—whether you're an international, an expat, or simply navigating life's challenges. Each post is designed to empower you with the clarity and strategies you need for personal growth.",
-			"contentSections": [],
-			"sections": []
+			"contentSections": []
 		}
 	},
 	{
@@ -136,8 +116,7 @@
 			"header": "Creating Positive Change in Your Relationships and Life",
 			"intro": "Life can feel complicated, whether you’re navigating relationships, work challenges, or cultural transitions. \n\nI’m Eleni Papamikrouli, a systemic therapist working with individuals, couples, and families. While I specialize in supporting internationals and expats, I welcome anyone seeking clarity and connection in their life.",
 			"content": "## Your Journey Starts Here\n\nAt the heart of my practice is the belief that every client’s experience is unique. I work to create a safe, supportive space where you can explore your challenges, uncover strengths, and find new paths forward. Whether you’re feeling stuck, overwhelmed, or simply curious about change, I’m here to help you navigate your personal journey.\n\n### A Personalized Approach\n\nMy approach is both holistic and tailored to you. I blend empathy with practical strategies drawn from systemic therapy to help you understand the patterns in your relationships, work, and personal life. This collaborative process is designed to empower you to make lasting, positive changes.\n\n### What You Can Expect\n\n- **Clarity and Insight:** We work together to gain a clear understanding of your current challenges and where you want to go.\n- **Actionable Strategies:** You’ll leave our sessions equipped with real-life tools to navigate change.\n- **A Caring Partnership:** I am committed to supporting you through every stage of your journey, with sensitivity to your unique experiences.\n- **Global Perspective:** While I specialize in supporting internationals and expats, my practice is open to anyone seeking growth, balance, and connection.\n\n### Let's Begin\n\nEvery step you take is an investment in a more fulfilling future. I invite you to explore the services offered, learn more about the transformative power of systemic therapy, and discover how you can begin creating positive change in your life.\n",
-			"contentSections": [],
-			"sections": []
+			"contentSections": []
 		}
 	}
 ]

--- a/src/lib/data/pages.json
+++ b/src/lib/data/pages.json
@@ -16,6 +16,7 @@
 			"header": "Get to Know Me",
 			"intro": "I’m Eleni Papamikrouli, a systemic therapist working with individuals, couples, and families. Originally from Greece, I’ve lived in the Netherlands for over 15 years, giving me a unique perspective on the experiences of internationals and expats. That said, I work with people from all walks of life, offering a safe and supportive space for anyone seeking change.",
 			"content": "## My approach \nI'm practical and collaborative. I combine curiosity with empathy to help clients explore their challenges and find ways forward. You don’t need to be perfect or have all the answers—therapy is about working together to create clarity and change.\n\n## Why Systemic Therapy?\nSystemic therapy focuses on the patterns and systems we live in, rather than labeling or diagnosing individuals. It’s not about finding fault but about exploring how dynamics work and where we can make meaningful shifts. My role is to guide you in uncovering possibilities and building solutions that fit your life.",
+			"contentSections": [],
 			"sections": [
 				{
 					"title": "About - Main content",
@@ -41,6 +42,7 @@
 			"header": "Contact Me to Take the First Step",
 			"intro": "Taking the first step toward therapy can feel daunting, but I’m here to make it as simple as possible. Whether you’re curious about the process or ready to begin, I’d love to hear from you.",
 			"content": "## Schedule a Session\nI work with people from all over the world and all walks of life. Let’s explore how therapy can help you create positive, lasting change.\n\n[Include a link or form for booking a session.]\n\n---\n\n## Contact Details\n- **Email:** eleni@mikrouli.nl\n- **Phone:** 00 31 6 19 44 62 63\n- **Languages:** Greek, Dutch, English\n- **Location:** Online sessions available worldwide",
+			"contentSections": [],
 			"sections": [
 				{
 					"title": "Contact - Main Content",
@@ -66,6 +68,7 @@
 			"header": "404 - Page not found",
 			"intro": "It seems the page you’re looking for doesn’t exist—or perhaps it’s just taking a little break.",
 			"content": "## Lost? Let's Find Our Way Together\n\nJust like in life, we sometimes encounter detours that redirect us to new paths. Let’s make this moment an opportunity to move forward.\n\nYou can:\n- [Return to the homepage](/)\n- [Learn more about me and my approach](/about)\n- [Contact me for support](/contact)\n\n> Take a deep breath, and let’s keep navigating this journey together.\n\n---\n\n### Still Stuck?\n\nIf you’re finding yourself here often, don’t hesitate to reach out. I’d love to help you find what you’re looking for—or perhaps we can use this as the first step toward something new.\n\nHere’s how to get in touch:\n\n- **Email**: [eleni@mikrouli.nl](mailto:eleni@mikrouli.nl)\n- **Phone**: 00 31 6 19 44 62 63\n- **Languages**: Greek, Dutch, English\n\nOr, [schedule a session directly](/contact). \n\n> Together, we can start creating clarity and positive change.",
+			"contentSections": [],
 			"sections": [
 				{
 					"title": "404 - Main content",
@@ -91,6 +94,7 @@
 			"header": "Explore Ways We Can Work Together",
 			"intro": "I provide therapy for anyone seeking to improve their relationships, navigate challenges, or better understand themselves. While I bring a unique perspective to working with internationals and expats, my services are open to all who want to create positive change.",
 			"content": "## Discover Our Approach\n\nWe believe that every individual’s journey is unique, and effective therapy should honor your personal story while offering practical tools to create positive change.\n\nOur services are designed with flexibility and empathy in mind. Whether you're looking to improve your relationships, overcome personal challenges, or simply gain clarity about your life direction, our tailored approach supports your growth every step of the way.\n",
+			"contentSections": [],
 			"sections": []
 		}
 	},
@@ -111,6 +115,7 @@
 			"header": "Insights to Support Your Journey",
 			"intro": "Therapy is about understanding ourselves and the systems we live in. Whether you're an international, an expat, or simply someone navigating life’s challenges, these articles offer insights and tools to support your journey.\n",
 			"content": "You'll discover concise, insightful articles that offer practical tools and fresh perspectives—whether you're an international, an expat, or simply navigating life's challenges. Each post is designed to empower you with the clarity and strategies you need for personal growth.",
+			"contentSections": [],
 			"sections": []
 		}
 	},
@@ -131,6 +136,7 @@
 			"header": "Creating Positive Change in Your Relationships and Life",
 			"intro": "Life can feel complicated, whether you’re navigating relationships, work challenges, or cultural transitions. \n\nI’m Eleni Papamikrouli, a systemic therapist working with individuals, couples, and families. While I specialize in supporting internationals and expats, I welcome anyone seeking clarity and connection in their life.",
 			"content": "## Your Journey Starts Here\n\nAt the heart of my practice is the belief that every client’s experience is unique. I work to create a safe, supportive space where you can explore your challenges, uncover strengths, and find new paths forward. Whether you’re feeling stuck, overwhelmed, or simply curious about change, I’m here to help you navigate your personal journey.\n\n### A Personalized Approach\n\nMy approach is both holistic and tailored to you. I blend empathy with practical strategies drawn from systemic therapy to help you understand the patterns in your relationships, work, and personal life. This collaborative process is designed to empower you to make lasting, positive changes.\n\n### What You Can Expect\n\n- **Clarity and Insight:** We work together to gain a clear understanding of your current challenges and where you want to go.\n- **Actionable Strategies:** You’ll leave our sessions equipped with real-life tools to navigate change.\n- **A Caring Partnership:** I am committed to supporting you through every stage of your journey, with sensitivity to your unique experiences.\n- **Global Perspective:** While I specialize in supporting internationals and expats, my practice is open to anyone seeking growth, balance, and connection.\n\n### Let's Begin\n\nEvery step you take is an investment in a more fulfilling future. I invite you to explore the services offered, learn more about the transformative power of systemic therapy, and discover how you can begin creating positive change in your life.\n",
+			"contentSections": [],
 			"sections": []
 		}
 	}

--- a/src/lib/data/pages.json
+++ b/src/lib/data/pages.json
@@ -1,10 +1,30 @@
 [
 	{
 		"meta": {
+			"id": "3rFQxFehQrVUuxDH8StNup",
+			"type": "Entry",
+			"createdAt": "2024-12-27T23:40:02.880Z",
+			"updatedAt": "2025-01-17T14:00:04.579Z",
+			"locale": "en-US"
+		},
+		"fields": {
+			"title": "Home",
+			"slug": "home",
+			"seoIndex": true,
+			"seoDescription": "Mikrouli systemic therapy is supportive space for clarity and positive change and navigate life’s challenges.",
+			"seoKeywords": "therapy, positive change, clarity, support, systemic",
+			"header": "Creating Positive Change in Your Relationships and Life",
+			"intro": "Life can feel complicated, whether you’re navigating relationships, work challenges, or cultural transitions. \n\nI’m Eleni Papamikrouli, a systemic therapist working with individuals, couples, and families. While I specialize in supporting internationals and expats, I welcome anyone seeking clarity and connection in their life.",
+			"content": "## Your Journey Starts Here\n\nAt the heart of my practice is the belief that every client’s experience is unique. I work to create a safe, supportive space where you can explore your challenges, uncover strengths, and find new paths forward. Whether you’re feeling stuck, overwhelmed, or simply curious about change, I’m here to help you navigate your personal journey.\n\n---\n\n### A Personalized Approach\n\nMy approach is both holistic and tailored to you. I blend empathy with practical strategies drawn from systemic therapy to help you understand the patterns in your relationships, work, and personal life. This collaborative process is designed to empower you to make lasting, positive changes.\n\n---\n\n### What You Can Expect\n\n- **Clarity and Insight:** We work together to gain a clear understanding of your current challenges and where you want to go.\n- **Actionable Strategies:** You’ll leave our sessions equipped with real-life tools to navigate change.\n- **A Caring Partnership:** I am committed to supporting you through every stage of your journey, with sensitivity to your unique experiences.\n- **Global Perspective:** While I specialize in supporting internationals and expats, my practice is open to anyone seeking growth, balance, and connection.\n\n---\n\n### Let's Begin\n\nEvery step you take is an investment in a more fulfilling future. I invite you to explore the services offered, learn more about the transformative power of systemic therapy, and discover how you can begin creating positive change in your life.\n",
+			"sections": []
+		}
+	},
+	{
+		"meta": {
 			"id": "61Vdx8qP4ItFip29IZbe9u",
 			"type": "Entry",
 			"createdAt": "2024-12-27T22:59:24.373Z",
-			"updatedAt": "2025-01-17T01:00:03.704Z",
+			"updatedAt": "2025-01-17T14:00:04.270Z",
 			"locale": "en-US"
 		},
 		"fields": {
@@ -15,28 +35,8 @@
 			"seoKeywords": "therapist, systemic, international, expat, relationships",
 			"header": "Get to Know Me",
 			"intro": "I’m Eleni Papamikrouli, a systemic therapist working with individuals, couples, and families. Originally from Greece, I’ve lived in the Netherlands for over 15 years, giving me a unique perspective on the experiences of internationals and expats. That said, I work with people from all walks of life, offering a safe and supportive space for anyone seeking change.",
-			"content": "## My approach \nI'm practical and collaborative. I combine curiosity with empathy to help clients explore their challenges and find ways forward. You don’t need to be perfect or have all the answers—therapy is about working together to create clarity and change.\n\n## Why Systemic Therapy?\nSystemic therapy focuses on the patterns and systems we live in, rather than labeling or diagnosing individuals. It’s not about finding fault but about exploring how dynamics work and where we can make meaningful shifts. My role is to guide you in uncovering possibilities and building solutions that fit your life.",
-			"contentSections": []
-		}
-	},
-	{
-		"meta": {
-			"id": "2FmTPol4nxNb4Q0elgN4oG",
-			"type": "Entry",
-			"createdAt": "2024-12-28T00:14:21.086Z",
-			"updatedAt": "2025-01-17T01:00:03.678Z",
-			"locale": "en-US"
-		},
-		"fields": {
-			"title": "Contact",
-			"slug": "contact",
-			"seoIndex": true,
-			"seoDescription": "Reach out for accessible therapy support. Contact me to begin your journey toward personal change and well-being.",
-			"seoKeywords": "system therapy, contact, support, counseling, healing",
-			"header": "Contact Me to Take the First Step",
-			"intro": "Taking the first step toward therapy can feel daunting, but I’m here to make it as simple as possible. Whether you’re curious about the process or ready to begin, I’d love to hear from you.",
-			"content": "## Schedule a Session\nI work with people from all over the world and all walks of life. Let’s explore how therapy can help you create positive, lasting change.\n\n[Include a link or form for booking a session.]\n\n---\n\n## Contact Details\n- **Email:** eleni@mikrouli.nl\n- **Phone:** 00 31 6 19 44 62 63\n- **Languages:** Greek, Dutch, English\n- **Location:** Online sessions available worldwide",
-			"contentSections": []
+			"content": "## My approach \nI'm practical and collaborative. I combine curiosity with empathy to help clients explore their challenges and find ways forward. You don’t need to be perfect or have all the answers—therapy is about working together to create clarity and change.\n\n---\n\n## Why Systemic Therapy?\nSystemic therapy focuses on the patterns and systems we live in, rather than labeling or diagnosing individuals. It’s not about finding fault but about exploring how dynamics work and where we can make meaningful shifts. My role is to guide you in uncovering possibilities and building solutions that fit your life.",
+			"sections": []
 		}
 	},
 	{
@@ -44,7 +44,7 @@
 			"id": "73rcZJ4hT1YtU28TI15VZp",
 			"type": "Entry",
 			"createdAt": "2025-01-08T02:59:42.227Z",
-			"updatedAt": "2025-01-17T01:00:03.362Z",
+			"updatedAt": "2025-01-17T14:00:04.144Z",
 			"locale": "en-US"
 		},
 		"fields": {
@@ -56,7 +56,27 @@
 			"header": "404 - Page not found",
 			"intro": "It seems the page you’re looking for doesn’t exist—or perhaps it’s just taking a little break.",
 			"content": "## Lost? Let's Find Our Way Together\n\nJust like in life, we sometimes encounter detours that redirect us to new paths. Let’s make this moment an opportunity to move forward.\n\nYou can:\n- [Return to the homepage](/)\n- [Learn more about me and my approach](/about)\n- [Contact me for support](/contact)\n\n> Take a deep breath, and let’s keep navigating this journey together.\n\n---\n\n### Still Stuck?\n\nIf you’re finding yourself here often, don’t hesitate to reach out. I’d love to help you find what you’re looking for—or perhaps we can use this as the first step toward something new.\n\nHere’s how to get in touch:\n\n- **Email**: [eleni@mikrouli.nl](mailto:eleni@mikrouli.nl)\n- **Phone**: 00 31 6 19 44 62 63\n- **Languages**: Greek, Dutch, English\n\nOr, [schedule a session directly](/contact). \n\n> Together, we can start creating clarity and positive change.",
-			"contentSections": []
+			"sections": []
+		}
+	},
+	{
+		"meta": {
+			"id": "2FmTPol4nxNb4Q0elgN4oG",
+			"type": "Entry",
+			"createdAt": "2024-12-28T00:14:21.086Z",
+			"updatedAt": "2025-01-17T14:00:03.821Z",
+			"locale": "en-US"
+		},
+		"fields": {
+			"title": "Contact",
+			"slug": "contact",
+			"seoIndex": true,
+			"seoDescription": "Reach out for accessible therapy support. Contact me to begin your journey toward personal change and well-being.",
+			"seoKeywords": "system therapy, contact, support, counseling, healing",
+			"header": "Contact Me to Take the First Step",
+			"intro": "Taking the first step toward therapy can feel daunting, but I’m here to make it as simple as possible. Whether you’re curious about the process or ready to begin, I’d love to hear from you.",
+			"content": "## Schedule a Session\nI work with people from all over the world and all walks of life. Let’s explore how therapy can help you create positive, lasting change.\n\n[Include a link or form for booking a session.]\n\n---\n\n## Contact Details\n- **Email:** eleni@mikrouli.nl\n- **Phone:** 00 31 6 19 44 62 63\n- **Languages:** Greek, Dutch, English\n- **Location:** Online sessions available worldwide",
+			"sections": []
 		}
 	},
 	{
@@ -76,7 +96,7 @@
 			"header": "Explore Ways We Can Work Together",
 			"intro": "I provide therapy for anyone seeking to improve their relationships, navigate challenges, or better understand themselves. While I bring a unique perspective to working with internationals and expats, my services are open to all who want to create positive change.",
 			"content": "## Discover Our Approach\n\nWe believe that every individual’s journey is unique, and effective therapy should honor your personal story while offering practical tools to create positive change.\n\nOur services are designed with flexibility and empathy in mind. Whether you're looking to improve your relationships, overcome personal challenges, or simply gain clarity about your life direction, our tailored approach supports your growth every step of the way.\n",
-			"contentSections": []
+			"sections": []
 		}
 	},
 	{
@@ -96,27 +116,7 @@
 			"header": "Insights to Support Your Journey",
 			"intro": "Therapy is about understanding ourselves and the systems we live in. Whether you're an international, an expat, or simply someone navigating life’s challenges, these articles offer insights and tools to support your journey.\n",
 			"content": "You'll discover concise, insightful articles that offer practical tools and fresh perspectives—whether you're an international, an expat, or simply navigating life's challenges. Each post is designed to empower you with the clarity and strategies you need for personal growth.",
-			"contentSections": []
-		}
-	},
-	{
-		"meta": {
-			"id": "3rFQxFehQrVUuxDH8StNup",
-			"type": "Entry",
-			"createdAt": "2024-12-27T23:40:02.880Z",
-			"updatedAt": "2025-01-17T01:00:03.016Z",
-			"locale": "en-US"
-		},
-		"fields": {
-			"title": "Home",
-			"slug": "home",
-			"seoIndex": true,
-			"seoDescription": "Mikrouli systemic therapy is supportive space for clarity and positive change and navigate life’s challenges.",
-			"seoKeywords": "therapy, positive change, clarity, support, systemic",
-			"header": "Creating Positive Change in Your Relationships and Life",
-			"intro": "Life can feel complicated, whether you’re navigating relationships, work challenges, or cultural transitions. \n\nI’m Eleni Papamikrouli, a systemic therapist working with individuals, couples, and families. While I specialize in supporting internationals and expats, I welcome anyone seeking clarity and connection in their life.",
-			"content": "## Your Journey Starts Here\n\nAt the heart of my practice is the belief that every client’s experience is unique. I work to create a safe, supportive space where you can explore your challenges, uncover strengths, and find new paths forward. Whether you’re feeling stuck, overwhelmed, or simply curious about change, I’m here to help you navigate your personal journey.\n\n### A Personalized Approach\n\nMy approach is both holistic and tailored to you. I blend empathy with practical strategies drawn from systemic therapy to help you understand the patterns in your relationships, work, and personal life. This collaborative process is designed to empower you to make lasting, positive changes.\n\n### What You Can Expect\n\n- **Clarity and Insight:** We work together to gain a clear understanding of your current challenges and where you want to go.\n- **Actionable Strategies:** You’ll leave our sessions equipped with real-life tools to navigate change.\n- **A Caring Partnership:** I am committed to supporting you through every stage of your journey, with sensitivity to your unique experiences.\n- **Global Perspective:** While I specialize in supporting internationals and expats, my practice is open to anyone seeking growth, balance, and connection.\n\n### Let's Begin\n\nEvery step you take is an investment in a more fulfilling future. I invite you to explore the services offered, learn more about the transformative power of systemic therapy, and discover how you can begin creating positive change in your life.\n",
-			"contentSections": []
+			"sections": []
 		}
 	}
 ]

--- a/src/lib/data/posts.json
+++ b/src/lib/data/posts.json
@@ -1,10 +1,64 @@
 [
 	{
 		"meta": {
+			"id": "5EA7KMYDmrAL2qk5VLuJdo",
+			"type": "Entry",
+			"createdAt": "2024-12-28T06:00:03.222Z",
+			"updatedAt": "2025-01-17T02:00:02.420Z",
+			"locale": "en-US"
+		},
+		"fields": {
+			"title": "Breaking Unhelpful Family Patterns",
+			"slug": "breaking-unhelpful-family-patterns",
+			"seoIndex": true,
+			"seoDescription": "Families are systems, and sometimes those systems get stuck. Learn how systemic therapy can help untangle unhealthy patterns and create space for change.",
+			"intro": "Families are systems, and sometimes those systems get stuck. Learn how systemic therapy can help untangle unhealthy patterns and create space for change.\n\n## Understanding Family Systems\nFamilies are made up of interconnected relationships, and sometimes those relationships develop patterns that stop working. These might show up as recurring arguments, strained communication, or feelings of disconnection.\n\n## How Systemic Therapy Helps\nSystemic therapy works to identify these patterns and help family members understand their roles within them. The goal isn’t to place blame but to explore how small changes can lead to significant improvements in the family dynamic.",
+			"contentSections": [],
+			"sections": []
+		}
+	},
+	{
+		"meta": {
+			"id": "3kryEmO4yykbYKbByiWU8i",
+			"type": "Entry",
+			"createdAt": "2024-12-28T06:00:04.205Z",
+			"updatedAt": "2025-01-17T02:00:02.394Z",
+			"locale": "en-US"
+		},
+		"fields": {
+			"title": "Cultural Sensitivity in Therapy",
+			"slug": "cultural-sensitivity-in-therapy",
+			"seoIndex": true,
+			"seoDescription": "Your cultural background matters. Therapy that acknowledges this can help you feel understood and supported in meaningful ways.",
+			"intro": "Your cultural background matters. Therapy that acknowledges this can help you feel understood and supported in meaningful ways.\n\n## Honoring Your Cultural Context\nOur cultural backgrounds influence how we see the world, express emotions, and relate to others. Therapy that recognizes this creates a safe and inclusive space for exploration.\n\n## Building Bridges\nIn systemic therapy, we work together to navigate cultural differences and build a deeper understanding of yourself and your relationships. Your experiences and identity are integral to the process.\n",
+			"contentSections": [],
+			"sections": []
+		}
+	},
+	{
+		"meta": {
+			"id": "1FcZOjCAszzKaiJxOAvKxA",
+			"type": "Entry",
+			"createdAt": "2024-12-28T06:00:03.284Z",
+			"updatedAt": "2025-01-17T02:00:02.383Z",
+			"locale": "en-US"
+		},
+		"fields": {
+			"title": "Understanding the Systems That Shape Us",
+			"slug": "understanding-the-systems-that-shape-us",
+			"seoIndex": true,
+			"seoDescription": "From families to workplaces, the systems we live in affect us deeply. Explore how systemic therapy helps you navigate these dynamics.",
+			"intro": "From families to workplaces, the systems we live in affect us deeply. Explore how systemic therapy helps you navigate these dynamics.\n\n## What Are Systems?\nSystems are the groups we belong to, from families to workplaces. These systems shape our behaviors, beliefs, and interactions, often in ways we don’t realize.\n\n## Making the Invisible Visible\nSystemic therapy helps you see these dynamics and identify where patterns might be holding you back. By addressing the system as a whole, we can find ways to create movement and change.",
+			"contentSections": [],
+			"sections": []
+		}
+	},
+	{
+		"meta": {
 			"id": "4K3cTBNASwMkrwkSSWm68w",
 			"type": "Entry",
 			"createdAt": "2024-12-28T06:00:04.384Z",
-			"updatedAt": "2025-01-17T01:19:52.404Z",
+			"updatedAt": "2025-01-17T02:00:02.310Z",
 			"locale": "en-US"
 		},
 		"fields": {
@@ -13,6 +67,7 @@
 			"seoIndex": true,
 			"seoDescription": "Many people think therapy is about diagnosing problems. Systemic therapy offers a different perspective—it’s about working with the systems around you.",
 			"intro": "Many people think therapy is about diagnosing problems. Systemic therapy offers a different perspective—it’s about working with the systems around you.",
+			"contentSections": [],
 			"sections": [
 				{
 					"title": "Therapy is not about fixing you - section main",
@@ -23,27 +78,10 @@
 	},
 	{
 		"meta": {
-			"id": "3kryEmO4yykbYKbByiWU8i",
-			"type": "Entry",
-			"createdAt": "2024-12-28T06:00:04.205Z",
-			"updatedAt": "2025-01-17T01:19:52.210Z",
-			"locale": "en-US"
-		},
-		"fields": {
-			"title": "Cultural Sensitivity in Therapy",
-			"slug": "cultural-sensitivity-in-therapy",
-			"seoIndex": true,
-			"seoDescription": "Your cultural background matters. Therapy that acknowledges this can help you feel understood and supported in meaningful ways.",
-			"intro": "Your cultural background matters. Therapy that acknowledges this can help you feel understood and supported in meaningful ways.\n\n## Honoring Your Cultural Context\nOur cultural backgrounds influence how we see the world, express emotions, and relate to others. Therapy that recognizes this creates a safe and inclusive space for exploration.\n\n## Building Bridges\nIn systemic therapy, we work together to navigate cultural differences and build a deeper understanding of yourself and your relationships. Your experiences and identity are integral to the process.\n",
-			"sections": []
-		}
-	},
-	{
-		"meta": {
 			"id": "4YPPEYrLxfl646mWntSl1O",
 			"type": "Entry",
 			"createdAt": "2024-12-28T06:00:04.003Z",
-			"updatedAt": "2025-01-17T01:19:52.163Z",
+			"updatedAt": "2025-01-17T02:00:02.297Z",
 			"locale": "en-US"
 		},
 		"fields": {
@@ -52,40 +90,7 @@
 			"seoIndex": true,
 			"seoDescription": "The expat experience is full of transitions and challenges. Here are some systemic tools to help you find stability and connection in a new culture.",
 			"intro": "The expat experience is full of transitions and challenges. Here are some systemic tools to help you find stability and connection in a new culture.\n\n## The Unique Challenges of Expat Life\nFrom language barriers to cultural differences, living abroad comes with its own set of struggles. These challenges often impact not just individuals but their families and relationships.\n\n## Finding Support and Connection\nSystemic therapy helps you understand how these challenges influence your life and relationships. Together, we explore strategies to create stability and a sense of belonging, no matter where you are.\n",
-			"sections": []
-		}
-	},
-	{
-		"meta": {
-			"id": "1FcZOjCAszzKaiJxOAvKxA",
-			"type": "Entry",
-			"createdAt": "2024-12-28T06:00:03.284Z",
-			"updatedAt": "2025-01-17T01:19:52.133Z",
-			"locale": "en-US"
-		},
-		"fields": {
-			"title": "Understanding the Systems That Shape Us",
-			"slug": "understanding-the-systems-that-shape-us",
-			"seoIndex": true,
-			"seoDescription": "From families to workplaces, the systems we live in affect us deeply. Explore how systemic therapy helps you navigate these dynamics.",
-			"intro": "From families to workplaces, the systems we live in affect us deeply. Explore how systemic therapy helps you navigate these dynamics.\n\n## What Are Systems?\nSystems are the groups we belong to, from families to workplaces. These systems shape our behaviors, beliefs, and interactions, often in ways we don’t realize.\n\n## Making the Invisible Visible\nSystemic therapy helps you see these dynamics and identify where patterns might be holding you back. By addressing the system as a whole, we can find ways to create movement and change.",
-			"sections": []
-		}
-	},
-	{
-		"meta": {
-			"id": "5EA7KMYDmrAL2qk5VLuJdo",
-			"type": "Entry",
-			"createdAt": "2024-12-28T06:00:03.222Z",
-			"updatedAt": "2025-01-17T01:19:52.100Z",
-			"locale": "en-US"
-		},
-		"fields": {
-			"title": "Breaking Unhelpful Family Patterns",
-			"slug": "breaking-unhelpful-family-patterns",
-			"seoIndex": true,
-			"seoDescription": "Families are systems, and sometimes those systems get stuck. Learn how systemic therapy can help untangle unhealthy patterns and create space for change.",
-			"intro": "Families are systems, and sometimes those systems get stuck. Learn how systemic therapy can help untangle unhealthy patterns and create space for change.\n\n## Understanding Family Systems\nFamilies are made up of interconnected relationships, and sometimes those relationships develop patterns that stop working. These might show up as recurring arguments, strained communication, or feelings of disconnection.\n\n## How Systemic Therapy Helps\nSystemic therapy works to identify these patterns and help family members understand their roles within them. The goal isn’t to place blame but to explore how small changes can lead to significant improvements in the family dynamic.",
+			"contentSections": [],
 			"sections": []
 		}
 	},
@@ -103,6 +108,7 @@
 			"seoIndex": true,
 			"seoDescription": "Systemic therapy can help you shift how you talk and listen.",
 			"intro": "Miscommunication is one of the most common sources of conflict in relationships. Systemic therapy can help you shift how you talk and listen.\n",
+			"contentSections": [],
 			"sections": [
 				{
 					"title": "Stengthening communication - Main section",

--- a/src/lib/data/posts.json
+++ b/src/lib/data/posts.json
@@ -4,7 +4,7 @@
 			"id": "5EA7KMYDmrAL2qk5VLuJdo",
 			"type": "Entry",
 			"createdAt": "2024-12-28T06:00:03.222Z",
-			"updatedAt": "2025-01-17T02:00:02.420Z",
+			"updatedAt": "2025-01-17T14:00:04.185Z",
 			"locale": "en-US"
 		},
 		"fields": {
@@ -12,76 +12,9 @@
 			"slug": "breaking-unhelpful-family-patterns",
 			"seoIndex": true,
 			"seoDescription": "Families are systems, and sometimes those systems get stuck. Learn how systemic therapy can help untangle unhealthy patterns and create space for change.",
-			"intro": "Families are systems, and sometimes those systems get stuck. Learn how systemic therapy can help untangle unhealthy patterns and create space for change.\n\n## Understanding Family Systems\nFamilies are made up of interconnected relationships, and sometimes those relationships develop patterns that stop working. These might show up as recurring arguments, strained communication, or feelings of disconnection.\n\n## How Systemic Therapy Helps\nSystemic therapy works to identify these patterns and help family members understand their roles within them. The goal isn’t to place blame but to explore how small changes can lead to significant improvements in the family dynamic.",
-			"contentSections": []
-		}
-	},
-	{
-		"meta": {
-			"id": "3kryEmO4yykbYKbByiWU8i",
-			"type": "Entry",
-			"createdAt": "2024-12-28T06:00:04.205Z",
-			"updatedAt": "2025-01-17T02:00:02.394Z",
-			"locale": "en-US"
-		},
-		"fields": {
-			"title": "Cultural Sensitivity in Therapy",
-			"slug": "cultural-sensitivity-in-therapy",
-			"seoIndex": true,
-			"seoDescription": "Your cultural background matters. Therapy that acknowledges this can help you feel understood and supported in meaningful ways.",
-			"intro": "Your cultural background matters. Therapy that acknowledges this can help you feel understood and supported in meaningful ways.\n\n## Honoring Your Cultural Context\nOur cultural backgrounds influence how we see the world, express emotions, and relate to others. Therapy that recognizes this creates a safe and inclusive space for exploration.\n\n## Building Bridges\nIn systemic therapy, we work together to navigate cultural differences and build a deeper understanding of yourself and your relationships. Your experiences and identity are integral to the process.\n",
-			"contentSections": []
-		}
-	},
-	{
-		"meta": {
-			"id": "1FcZOjCAszzKaiJxOAvKxA",
-			"type": "Entry",
-			"createdAt": "2024-12-28T06:00:03.284Z",
-			"updatedAt": "2025-01-17T02:00:02.383Z",
-			"locale": "en-US"
-		},
-		"fields": {
-			"title": "Understanding the Systems That Shape Us",
-			"slug": "understanding-the-systems-that-shape-us",
-			"seoIndex": true,
-			"seoDescription": "From families to workplaces, the systems we live in affect us deeply. Explore how systemic therapy helps you navigate these dynamics.",
-			"intro": "From families to workplaces, the systems we live in affect us deeply. Explore how systemic therapy helps you navigate these dynamics.\n\n## What Are Systems?\nSystems are the groups we belong to, from families to workplaces. These systems shape our behaviors, beliefs, and interactions, often in ways we don’t realize.\n\n## Making the Invisible Visible\nSystemic therapy helps you see these dynamics and identify where patterns might be holding you back. By addressing the system as a whole, we can find ways to create movement and change.",
-			"contentSections": []
-		}
-	},
-	{
-		"meta": {
-			"id": "4K3cTBNASwMkrwkSSWm68w",
-			"type": "Entry",
-			"createdAt": "2024-12-28T06:00:04.384Z",
-			"updatedAt": "2025-01-17T02:00:02.310Z",
-			"locale": "en-US"
-		},
-		"fields": {
-			"title": "Why Therapy Isn’t About Fixing You",
-			"slug": "why-therapy-isnt-about-fixing-you",
-			"seoIndex": true,
-			"seoDescription": "Many people think therapy is about diagnosing problems. Systemic therapy offers a different perspective—it’s about working with the systems around you.",
-			"intro": "Many people think therapy is about diagnosing problems. Systemic therapy offers a different perspective—it’s about working with the systems around you.",
-			"contentSections": []
-		}
-	},
-	{
-		"meta": {
-			"id": "4YPPEYrLxfl646mWntSl1O",
-			"type": "Entry",
-			"createdAt": "2024-12-28T06:00:04.003Z",
-			"updatedAt": "2025-01-17T02:00:02.297Z",
-			"locale": "en-US"
-		},
-		"fields": {
-			"title": "Adapting to Life Abroad",
-			"slug": "adapting-to-life-abroad",
-			"seoIndex": true,
-			"seoDescription": "The expat experience is full of transitions and challenges. Here are some systemic tools to help you find stability and connection in a new culture.",
-			"intro": "The expat experience is full of transitions and challenges. Here are some systemic tools to help you find stability and connection in a new culture.\n\n## The Unique Challenges of Expat Life\nFrom language barriers to cultural differences, living abroad comes with its own set of struggles. These challenges often impact not just individuals but their families and relationships.\n\n## Finding Support and Connection\nSystemic therapy helps you understand how these challenges influence your life and relationships. Together, we explore strategies to create stability and a sense of belonging, no matter where you are.\n",
-			"contentSections": []
+			"intro": "Families are systems, and sometimes those systems get stuck. Learn how systemic therapy can help untangle unhealthy patterns and create space for change.",
+			"content": "## Understanding Family Systems\nFamilies are made up of interconnected relationships, and sometimes those relationships develop patterns that stop working. These might show up as recurring arguments, strained communication, or feelings of disconnection.\n\n---\n\n## How Systemic Therapy Helps\nSystemic therapy works to identify these patterns and help family members understand their roles within them. The goal isn’t to place blame but to explore how small changes can lead to significant improvements in the family dynamic.",
+			"sections": []
 		}
 	},
 	{
@@ -89,7 +22,7 @@
 			"id": "3JNNx7W7oR8vIgTdggece",
 			"type": "Entry",
 			"createdAt": "2024-12-28T06:00:04.415Z",
-			"updatedAt": "2025-01-17T01:00:03.837Z",
+			"updatedAt": "2025-01-17T14:00:04.101Z",
 			"locale": "en-US"
 		},
 		"fields": {
@@ -98,7 +31,80 @@
 			"seoIndex": true,
 			"seoDescription": "Systemic therapy can help you shift how you talk and listen.",
 			"intro": "Miscommunication is one of the most common sources of conflict in relationships. Systemic therapy can help you shift how you talk and listen.\n",
-			"contentSections": []
+			"content": "## Why Communication Matters\nAt its core, communication is how we connect. But when communication breaks down, misunderstandings and conflict arise, creating distance in relationships.\n\n---\n\n## Tools for Effective Communication\nSystemic therapy provides practical tools to help you listen more openly, express yourself clearly, and rebuild trust. Small shifts in how you communicate can lead to profound changes in your relationships.\n",
+			"sections": []
+		}
+	},
+	{
+		"meta": {
+			"id": "4K3cTBNASwMkrwkSSWm68w",
+			"type": "Entry",
+			"createdAt": "2024-12-28T06:00:04.384Z",
+			"updatedAt": "2025-01-17T14:00:03.880Z",
+			"locale": "en-US"
+		},
+		"fields": {
+			"title": "Why Therapy Isn’t About Fixing You",
+			"slug": "why-therapy-isnt-about-fixing-you",
+			"seoIndex": true,
+			"seoDescription": "Many people think therapy is about diagnosing problems. Systemic therapy offers a different perspective—it’s about working with the systems around you.",
+			"intro": "Many people think therapy is about diagnosing problems. Systemic therapy offers a different perspective—it’s about working with the systems around you.",
+			"content": "## Moving Beyond Labels\nSystemic therapy takes a different approach by stepping away from the idea of diagnosing individuals. Instead, it focuses on the systems we live in—families, workplaces, and communities.\n\n---\n\n## Exploring Possibilities\nRather than seeing yourself as flawed, systemic therapy helps you explore how the patterns in your life shape your experiences. It’s a process of curiosity and discovery, rather than one of fault-finding.",
+			"sections": []
+		}
+	},
+	{
+		"meta": {
+			"id": "3kryEmO4yykbYKbByiWU8i",
+			"type": "Entry",
+			"createdAt": "2024-12-28T06:00:04.205Z",
+			"updatedAt": "2025-01-17T14:00:03.647Z",
+			"locale": "en-US"
+		},
+		"fields": {
+			"title": "Cultural Sensitivity in Therapy",
+			"slug": "cultural-sensitivity-in-therapy",
+			"seoIndex": true,
+			"seoDescription": "Your cultural background matters. Therapy that acknowledges this can help you feel understood and supported in meaningful ways.",
+			"intro": "Your cultural background matters. Therapy that acknowledges this can help you feel understood and supported in meaningful ways.\n",
+			"content": "## Honoring Your Cultural Context\nOur cultural backgrounds influence how we see the world, express emotions, and relate to others. Therapy that recognizes this creates a safe and inclusive space for exploration.\n\n---\n\n## Building Bridges\nIn systemic therapy, we work together to navigate cultural differences and build a deeper understanding of yourself and your relationships. Your experiences and identity are integral to the process.",
+			"sections": []
+		}
+	},
+	{
+		"meta": {
+			"id": "1FcZOjCAszzKaiJxOAvKxA",
+			"type": "Entry",
+			"createdAt": "2024-12-28T06:00:03.284Z",
+			"updatedAt": "2025-01-17T14:00:03.605Z",
+			"locale": "en-US"
+		},
+		"fields": {
+			"title": "Understanding the Systems That Shape Us",
+			"slug": "understanding-the-systems-that-shape-us",
+			"seoIndex": true,
+			"seoDescription": "From families to workplaces, the systems we live in affect us deeply. Explore how systemic therapy helps you navigate these dynamics.",
+			"intro": "From families to workplaces, the systems we live in affect us deeply. Explore how systemic therapy helps you navigate these dynamics.",
+			"content": "## What Are Systems?\nSystems are the groups we belong to, from families to workplaces. These systems shape our behaviors, beliefs, and interactions, often in ways we don’t realize.\n\n---\n\n## Making the Invisible Visible\nSystemic therapy helps you see these dynamics and identify where patterns might be holding you back. By addressing the system as a whole, we can find ways to create movement and change.",
+			"sections": []
+		}
+	},
+	{
+		"meta": {
+			"id": "4YPPEYrLxfl646mWntSl1O",
+			"type": "Entry",
+			"createdAt": "2024-12-28T06:00:04.003Z",
+			"updatedAt": "2025-01-17T14:00:03.533Z",
+			"locale": "en-US"
+		},
+		"fields": {
+			"title": "Adapting to Life Abroad",
+			"slug": "adapting-to-life-abroad",
+			"seoIndex": true,
+			"seoDescription": "The expat experience is full of transitions and challenges. Here are some systemic tools to help you find stability and connection in a new culture.",
+			"intro": "The expat experience is full of transitions and challenges. Here are some systemic tools to help you find stability and connection in a new culture.\n",
+			"content": "## The Unique Challenges of Expat Life\nFrom language barriers to cultural differences, living abroad comes with its own set of struggles. These challenges often impact not just individuals but their families and relationships.\n\n---\n\n## Finding Support and Connection\nSystemic therapy helps you understand how these challenges influence your life and relationships. Together, we explore strategies to create stability and a sense of belonging, no matter where you are.## The Unique Challenges of Expat Life\nFrom language barriers to cultural differences, living abroad comes with its own set of struggles. These challenges often impact not just individuals but their families and relationships.",
+			"sections": []
 		}
 	}
 ]

--- a/src/lib/data/posts.json
+++ b/src/lib/data/posts.json
@@ -13,8 +13,7 @@
 			"seoIndex": true,
 			"seoDescription": "Families are systems, and sometimes those systems get stuck. Learn how systemic therapy can help untangle unhealthy patterns and create space for change.",
 			"intro": "Families are systems, and sometimes those systems get stuck. Learn how systemic therapy can help untangle unhealthy patterns and create space for change.\n\n## Understanding Family Systems\nFamilies are made up of interconnected relationships, and sometimes those relationships develop patterns that stop working. These might show up as recurring arguments, strained communication, or feelings of disconnection.\n\n## How Systemic Therapy Helps\nSystemic therapy works to identify these patterns and help family members understand their roles within them. The goal isn’t to place blame but to explore how small changes can lead to significant improvements in the family dynamic.",
-			"contentSections": [],
-			"sections": []
+			"contentSections": []
 		}
 	},
 	{
@@ -31,8 +30,7 @@
 			"seoIndex": true,
 			"seoDescription": "Your cultural background matters. Therapy that acknowledges this can help you feel understood and supported in meaningful ways.",
 			"intro": "Your cultural background matters. Therapy that acknowledges this can help you feel understood and supported in meaningful ways.\n\n## Honoring Your Cultural Context\nOur cultural backgrounds influence how we see the world, express emotions, and relate to others. Therapy that recognizes this creates a safe and inclusive space for exploration.\n\n## Building Bridges\nIn systemic therapy, we work together to navigate cultural differences and build a deeper understanding of yourself and your relationships. Your experiences and identity are integral to the process.\n",
-			"contentSections": [],
-			"sections": []
+			"contentSections": []
 		}
 	},
 	{
@@ -49,8 +47,7 @@
 			"seoIndex": true,
 			"seoDescription": "From families to workplaces, the systems we live in affect us deeply. Explore how systemic therapy helps you navigate these dynamics.",
 			"intro": "From families to workplaces, the systems we live in affect us deeply. Explore how systemic therapy helps you navigate these dynamics.\n\n## What Are Systems?\nSystems are the groups we belong to, from families to workplaces. These systems shape our behaviors, beliefs, and interactions, often in ways we don’t realize.\n\n## Making the Invisible Visible\nSystemic therapy helps you see these dynamics and identify where patterns might be holding you back. By addressing the system as a whole, we can find ways to create movement and change.",
-			"contentSections": [],
-			"sections": []
+			"contentSections": []
 		}
 	},
 	{
@@ -67,13 +64,7 @@
 			"seoIndex": true,
 			"seoDescription": "Many people think therapy is about diagnosing problems. Systemic therapy offers a different perspective—it’s about working with the systems around you.",
 			"intro": "Many people think therapy is about diagnosing problems. Systemic therapy offers a different perspective—it’s about working with the systems around you.",
-			"contentSections": [],
-			"sections": [
-				{
-					"title": "Therapy is not about fixing you - section main",
-					"content": "## Moving Beyond Labels\nSystemic therapy takes a different approach by stepping away from the idea of diagnosing individuals. Instead, it focuses on the systems we live in—families, workplaces, and communities.\n\n## Exploring Possibilities\nRather than seeing yourself as flawed, systemic therapy helps you explore how the patterns in your life shape your experiences. It’s a process of curiosity and discovery, rather than one of fault-finding."
-				}
-			]
+			"contentSections": []
 		}
 	},
 	{
@@ -90,8 +81,7 @@
 			"seoIndex": true,
 			"seoDescription": "The expat experience is full of transitions and challenges. Here are some systemic tools to help you find stability and connection in a new culture.",
 			"intro": "The expat experience is full of transitions and challenges. Here are some systemic tools to help you find stability and connection in a new culture.\n\n## The Unique Challenges of Expat Life\nFrom language barriers to cultural differences, living abroad comes with its own set of struggles. These challenges often impact not just individuals but their families and relationships.\n\n## Finding Support and Connection\nSystemic therapy helps you understand how these challenges influence your life and relationships. Together, we explore strategies to create stability and a sense of belonging, no matter where you are.\n",
-			"contentSections": [],
-			"sections": []
+			"contentSections": []
 		}
 	},
 	{
@@ -108,13 +98,7 @@
 			"seoIndex": true,
 			"seoDescription": "Systemic therapy can help you shift how you talk and listen.",
 			"intro": "Miscommunication is one of the most common sources of conflict in relationships. Systemic therapy can help you shift how you talk and listen.\n",
-			"contentSections": [],
-			"sections": [
-				{
-					"title": "Stengthening communication - Main section",
-					"content": "## Why Communication Matters\nAt its core, communication is how we connect. But when communication breaks down, misunderstandings and conflict arise, creating distance in relationships.\n\n## Tools for Effective Communication\nSystemic therapy provides practical tools to help you listen more openly, express yourself clearly, and rebuild trust. Small shifts in how you communicate can lead to profound changes in your relationships.\n"
-				}
-			]
+			"contentSections": []
 		}
 	}
 ]

--- a/src/lib/data/services.json
+++ b/src/lib/data/services.json
@@ -14,8 +14,7 @@
 			"seoDescription": "I help families uncover and change unhelpful patterns, creating healthier ways of relating and supporting each other.",
 			"header": "Family Therapy",
 			"intro": "Families operate as systems, and sometimes those systems get stuck. I help\nfamilies uncover and change unhelpful patterns, creating healthier ways of\nrelating and supporting each other.",
-			"contentSections": [],
-			"sections": []
+			"contentSections": []
 		}
 	},
 	{
@@ -33,8 +32,7 @@
 			"seoDescription": "I work with couples of all backgrounds to improve communication, resolve conflicts, and strengthen their connection.",
 			"header": "Couples Therapy",
 			"intro": "Every relationship has its own dynamics and struggles. I work with couples of\nall backgrounds to improve communication, resolve conflicts, and strengthen\ntheir connection.",
-			"contentSections": [],
-			"sections": []
+			"contentSections": []
 		}
 	},
 	{
@@ -52,8 +50,7 @@
 			"seoDescription": "For those seeking personal growth and clarity, individual therapy offers a space to explore challenges and patterns that may be holding you back. ",
 			"header": "Individual Therapy",
 			"intro": "For those seeking personal growth and clarity, individual therapy offers a space\nto explore challenges and patterns that may be holding you back. Whether you’re\ndealing with anxiety, cultural transitions, or life stress, we’ll work together\nto find new possibilities.",
-			"contentSections": [],
-			"sections": []
+			"contentSections": []
 		}
 	}
 ]

--- a/src/lib/data/services.json
+++ b/src/lib/data/services.json
@@ -14,7 +14,7 @@
 			"seoDescription": "I help families uncover and change unhelpful patterns, creating healthier ways of relating and supporting each other.",
 			"header": "Family Therapy",
 			"intro": "Families operate as systems, and sometimes those systems get stuck. I help\nfamilies uncover and change unhelpful patterns, creating healthier ways of\nrelating and supporting each other.",
-			"contentSections": []
+			"sections": []
 		}
 	},
 	{
@@ -32,7 +32,7 @@
 			"seoDescription": "I work with couples of all backgrounds to improve communication, resolve conflicts, and strengthen their connection.",
 			"header": "Couples Therapy",
 			"intro": "Every relationship has its own dynamics and struggles. I work with couples of\nall backgrounds to improve communication, resolve conflicts, and strengthen\ntheir connection.",
-			"contentSections": []
+			"sections": []
 		}
 	},
 	{
@@ -50,7 +50,7 @@
 			"seoDescription": "For those seeking personal growth and clarity, individual therapy offers a space to explore challenges and patterns that may be holding you back. ",
 			"header": "Individual Therapy",
 			"intro": "For those seeking personal growth and clarity, individual therapy offers a space\nto explore challenges and patterns that may be holding you back. Whether you’re\ndealing with anxiety, cultural transitions, or life stress, we’ll work together\nto find new possibilities.",
-			"contentSections": []
+			"sections": []
 		}
 	}
 ]

--- a/src/lib/data/services.json
+++ b/src/lib/data/services.json
@@ -14,6 +14,7 @@
 			"seoDescription": "I help families uncover and change unhelpful patterns, creating healthier ways of relating and supporting each other.",
 			"header": "Family Therapy",
 			"intro": "Families operate as systems, and sometimes those systems get stuck. I help\nfamilies uncover and change unhelpful patterns, creating healthier ways of\nrelating and supporting each other.",
+			"contentSections": [],
 			"sections": []
 		}
 	},
@@ -32,6 +33,7 @@
 			"seoDescription": "I work with couples of all backgrounds to improve communication, resolve conflicts, and strengthen their connection.",
 			"header": "Couples Therapy",
 			"intro": "Every relationship has its own dynamics and struggles. I work with couples of\nall backgrounds to improve communication, resolve conflicts, and strengthen\ntheir connection.",
+			"contentSections": [],
 			"sections": []
 		}
 	},
@@ -50,6 +52,7 @@
 			"seoDescription": "For those seeking personal growth and clarity, individual therapy offers a space to explore challenges and patterns that may be holding you back. ",
 			"header": "Individual Therapy",
 			"intro": "For those seeking personal growth and clarity, individual therapy offers a space\nto explore challenges and patterns that may be holding you back. Whether you’re\ndealing with anxiety, cultural transitions, or life stress, we’ll work together\nto find new possibilities.",
+			"contentSections": [],
 			"sections": []
 		}
 	}

--- a/src/lib/server/content.js
+++ b/src/lib/server/content.js
@@ -61,7 +61,7 @@ export const getPage = (slug) => {
 	return {
 		...page.fields,
 		intro: markdownToHtml(page.fields.intro),
-		contentSections: splitText(markdownToHtml(page.fields?.content)),
+		sections: splitText(markdownToHtml(page.fields?.content)),
 	};
 };
 
@@ -81,7 +81,7 @@ export const getService = (slug) => {
 	return {
 		...service.fields,
 		intro: markdownToHtml(service.fields.intro),
-		contentSections: splitText(markdownToHtml(service.fields.content)),
+		sections: splitText(markdownToHtml(service.fields.content)),
 	};
 };
 
@@ -125,7 +125,7 @@ export const getPost = (slug) => {
 	return {
 		...post.fields,
 		intro: markdownToHtml(post.fields.intro),
-		contentSections: splitText(markdownToHtml(post.fields.content)),
+		sections: splitText(markdownToHtml(post.fields.content)),
 	};
 };
 

--- a/src/lib/server/content.js
+++ b/src/lib/server/content.js
@@ -11,7 +11,7 @@ import postItems from "../data/posts.json";
 import seoData from "../data/seo.json";
 /** @type {import("$lib/types/contentful").ServiceEntry[]}*/
 import serviceItems from "../data/services.json";
-import { markdownToHtml } from "./utils.js";
+import { markdownToHtml, splitText } from "./utils.js";
 
 /**
  * Fetch all content data.
@@ -68,7 +68,7 @@ export const getPage = (slug) => {
 	return {
 		...page.fields,
 		intro: markdownToHtml(page.fields.intro),
-		content: markdownToHtml(page.fields.content),
+		contentSections: splitText(markdownToHtml(page.fields?.content)),
 		sections,
 	};
 };
@@ -96,7 +96,7 @@ export const getService = (slug) => {
 	return {
 		...service.fields,
 		intro: markdownToHtml(service.fields.intro),
-		content: markdownToHtml(service.fields.content),
+		contentSections: splitText(markdownToHtml(service.fields.content)),
 		sections,
 	};
 };
@@ -148,7 +148,7 @@ export const getPost = (slug) => {
 	return {
 		...post.fields,
 		intro: markdownToHtml(post.fields.intro),
-		content: markdownToHtml(post.fields?.content),
+		contentSections: splitText(markdownToHtml(post.fields.content)),
 		sections,
 	};
 };

--- a/src/lib/server/content.js
+++ b/src/lib/server/content.js
@@ -58,18 +58,10 @@ export const getPage = (slug) => {
 
 	if (!page) throw error(404, `Page with slug '${slug}' not found`);
 
-	/** @type {import('$lib/types/contentful').SectionFields[]}*/
-	let sections = page.fields.sections;
-	sections = sections?.map((section) => ({
-		...section,
-		content: markdownToHtml(section.content),
-	}));
-
 	return {
 		...page.fields,
 		intro: markdownToHtml(page.fields.intro),
 		contentSections: splitText(markdownToHtml(page.fields?.content)),
-		sections,
 	};
 };
 
@@ -86,18 +78,10 @@ export const getService = (slug) => {
 
 	if (!service) throw error(404, `Service with slug '${slug}' not found`);
 
-	/** @type {import('$lib/types/contentful').SectionFields[]}*/
-	let sections = service.fields.sections;
-	sections = sections?.map((section) => ({
-		...section,
-		content: markdownToHtml(section.content),
-	}));
-
 	return {
 		...service.fields,
 		intro: markdownToHtml(service.fields.intro),
 		contentSections: splitText(markdownToHtml(service.fields.content)),
-		sections,
 	};
 };
 
@@ -138,18 +122,10 @@ export const getPost = (slug) => {
 
 	if (!post) throw error(404, `Blog post with slug '${slug}' not found`);
 
-	/** @type {import('$lib/types/contentful').SectionFields[]}*/
-	let sections = post.fields.sections;
-	sections = sections?.map((section) => ({
-		...section,
-		content: markdownToHtml(section.content),
-	}));
-
 	return {
 		...post.fields,
 		intro: markdownToHtml(post.fields.intro),
 		contentSections: splitText(markdownToHtml(post.fields.content)),
-		sections,
 	};
 };
 

--- a/src/lib/server/utils.js
+++ b/src/lib/server/utils.js
@@ -18,7 +18,7 @@ import { gfmHeadingId } from "marked-gfm-heading-id";
  * const fooBar = (i, n) => i + n; // Curried function
  * const addOneThenDouble = compose(foo, bar, (i) => fooBar(i, 1));
  */
-const processSync =
+export const processSync =
 	(...functions) =>
 	(input) =>
 		functions.reduce((value, fn) => fn(value), input);
@@ -58,6 +58,7 @@ export const splitText = (text, identifier = "<hr>") => {
  */
 export const markdownToHtml = (markdown) => {
 	if (!markdown) return "";
+
 	marked.use(gfmHeadingId({ prefix: "heading-" }));
 	const htmlProcessor = processSync(
 		(input) => marked(input, { async: false, breaks: true }),

--- a/src/lib/types/contentful.d.ts
+++ b/src/lib/types/contentful.d.ts
@@ -16,6 +16,10 @@ export type BaseFields = {
 	header?: string;
 	intro: string;
 	content?: string;
+	contentSections: string[];
+	/**
+	 * @deprecated Use `contentSections` instead.
+	 */
 	sections: SectionFields[];
 };
 

--- a/src/lib/types/contentful.d.ts
+++ b/src/lib/types/contentful.d.ts
@@ -16,7 +16,7 @@ export type BaseFields = {
 	header?: string;
 	intro: string;
 	content?: string;
-	contentSections: string[];
+	sections: string[];
 };
 
 // ### Pages

--- a/src/lib/types/contentful.d.ts
+++ b/src/lib/types/contentful.d.ts
@@ -17,10 +17,6 @@ export type BaseFields = {
 	intro: string;
 	content?: string;
 	contentSections: string[];
-	/**
-	 * @deprecated Use `contentSections` instead.
-	 */
-	sections: SectionFields[];
 };
 
 // ### Pages
@@ -29,17 +25,6 @@ export type PageFields = BaseFields & {};
 export type PageEntry = {
 	meta: Metadata;
 	fields: PageFields;
-};
-
-// ### Sections
-export type SectionEntry = {
-	meta: Metadata;
-	fields?: SectionFields;
-};
-export type SectionFields = {
-	title: string;
-	header?: string;
-	content: string;
 };
 
 // ### Services

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,13 +3,15 @@ import Hero from "$lib/components/layout/Hero.svelte";
 import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { header, intro, content } = data.local;
+let { header, intro, contentSections } = data.local;
 </script>
 
 <Hero title={header}>
 	{@html intro}
 </Hero>
 
-<Section>
-	<div class="prose prose-base">{@html content}</div>
-</Section>
+{#each contentSections as section}
+	<Section>
+		<div class="prose prose-base">{@html section}</div>
+	</Section>
+{/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,14 +3,14 @@ import Hero from "$lib/components/layout/Hero.svelte";
 import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { header, intro, contentSections } = data.local;
+let { header, intro, sections } = data.local;
 </script>
 
 <Hero title={header}>
 	{@html intro}
 </Hero>
 
-{#each contentSections as section}
+{#each sections as section}
 	<Section>
 		<div class="prose prose-base">{@html section}</div>
 	</Section>

--- a/src/routes/404/+page.svelte
+++ b/src/routes/404/+page.svelte
@@ -3,18 +3,15 @@ import Hero from "$lib/components/layout/Hero.svelte";
 import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { header, intro, sections } = data.local;
+let { header, intro, contentSections } = data.local;
 </script>
 
 <Hero title={header}>
 	{@html intro}
 </Hero>
 
-{#each sections as section}
-	<Section classes="p-8">
-		{#if section.header}
-			<h2 class="mb-4 text-3xl font-bold">{section.header}</h2>
-		{/if}
-		<div class="prose prose-base">{@html section.content}</div>
+{#each contentSections as section}
+	<Section>
+		<div class="prose prose-base">{@html section}</div>
 	</Section>
 {/each}

--- a/src/routes/404/+page.svelte
+++ b/src/routes/404/+page.svelte
@@ -3,14 +3,14 @@ import Hero from "$lib/components/layout/Hero.svelte";
 import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { header, intro, contentSections } = data.local;
+let { header, intro, sections } = data.local;
 </script>
 
 <Hero title={header}>
 	{@html intro}
 </Hero>
 
-{#each contentSections as section}
+{#each sections as section}
 	<Section>
 		<div class="prose prose-base">{@html section}</div>
 	</Section>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -3,14 +3,14 @@ import Hero from "$lib/components/layout/Hero.svelte";
 import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { header, intro, contentSections } = data.local;
+let { header, intro, sections } = data.local;
 </script>
 
 <Hero title={header}>
 	{@html intro}
 </Hero>
 
-{#each contentSections as section}
+{#each sections as section}
 	<Section>
 		<div class="prose prose-base">{@html section}</div>
 	</Section>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -3,18 +3,15 @@ import Hero from "$lib/components/layout/Hero.svelte";
 import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { header, intro, sections } = data.local;
+let { header, intro, contentSections } = data.local;
 </script>
 
 <Hero title={header}>
 	{@html intro}
 </Hero>
- 
-{#each sections as section}
+
+{#each contentSections as section}
 	<Section>
-		{#if section.header}
-			<h2 class="mb-4 text-3xl font-bold">{section.header}</h2>
-		{/if}
-		<div class="prose prose-base">{@html section.content}</div>
+		<div class="prose prose-base">{@html section}</div>
 	</Section>
 {/each}

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -3,14 +3,14 @@ import Hero from "$lib/components/layout/Hero.svelte";
 import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { title, intro, contentSections } = data.local;
+let { title, intro, sections } = data.local;
 </script>
 
 <Hero title={title}>
 	{@html intro}
 </Hero>
 
-{#each contentSections as section}
+{#each sections as section}
 	<Section>
 		<div class="prose prose-base">{@html section}</div>
 	</Section>

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -1,10 +1,17 @@
 <script>
 import Hero from "$lib/components/layout/Hero.svelte";
+import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { title, intro } = data.local;
+let { title, intro, contentSections } = data.local;
 </script>
 
 <Hero title={title}>
 	{@html intro}
 </Hero>
+
+{#each contentSections as section}
+	<Section>
+		<div class="prose prose-base">{@html section}</div>
+	</Section>
+{/each}

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -3,18 +3,15 @@ import Hero from "$lib/components/layout/Hero.svelte";
 import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { header, intro, sections } = data.local;
+let { header, intro, contentSections } = data.local;
 </script>
 
 <Hero title={header}>
 	{@html intro}
 </Hero>
 
-{#each sections as section}
-	<Section classes="p-8">
-		{#if section.header}
-			<h2 class="mb-4 text-3xl font-bold">{section.header}</h2>
-		{/if}
-		<div class="prose prose-base">{@html section.content}</div>
+{#each contentSections as section}
+	<Section>
+		<div class="prose prose-base">{@html section}</div>
 	</Section>
 {/each}

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -3,14 +3,14 @@ import Hero from "$lib/components/layout/Hero.svelte";
 import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { header, intro, contentSections } = data.local;
+let { header, intro, sections } = data.local;
 </script>
 
 <Hero title={header}>
 	{@html intro}
 </Hero>
 
-{#each contentSections as section}
+{#each sections as section}
 	<Section>
 		<div class="prose prose-base">{@html section}</div>
 	</Section>

--- a/src/routes/services/[slug]/+page.svelte
+++ b/src/routes/services/[slug]/+page.svelte
@@ -3,14 +3,14 @@ import Hero from "$lib/components/layout/Hero.svelte";
 import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { title, intro, contentSections } = data.local;
+let { title, intro, sections } = data.local;
 </script>
 
 <Hero {title}>
 	{@html intro}
 </Hero>
 
-{#each contentSections as section}
+{#each sections as section}
 	<Section>
 		<div class="prose prose-base">{@html section}</div>
 	</Section>

--- a/src/routes/services/[slug]/+page.svelte
+++ b/src/routes/services/[slug]/+page.svelte
@@ -1,10 +1,17 @@
 <script>
 import Hero from "$lib/components/layout/Hero.svelte";
+import Section from "$lib/components/layout/Section.svelte";
 
 let { data } = $props();
-let { title, intro } = data.local;
+let { title, intro, contentSections } = data.local;
 </script>
 
 <Hero {title}>
 	{@html intro}
 </Hero>
+
+{#each contentSections as section}
+	<Section>
+		<div class="prose prose-base">{@html section}</div>
+	</Section>
+{/each}


### PR DESCRIPTION
Simplify content editing by using one field with a markdown `---` horizontal rule as delimiter for content sections